### PR TITLE
fix: add space to mp4 ffmpeg command

### DIFF
--- a/main.py
+++ b/main.py
@@ -303,7 +303,7 @@ def post_process(filename, cropvalue, item_path, bitrate):
                     logging.info("Subs found")
                     sub_file = f"-i \"cache/{filename}.en.vtt\" -map 0:v -map 0:a -map 1 -metadata:s:s:0 language=eng " \
                                f"-disposition:s:0 forced -c:s ssa "
-            subprocess.check_call(f'ffmpeg -i "{filename}" {sub_file} -threads {thread_count} -vf {cropvalue} -c:v libx264 -b:v {bitrate*140}'
+            subprocess.check_call(f'ffmpeg -i "{filename}" {sub_file} -threads {thread_count} -vf {cropvalue} -c:v libx264 -b:v {bitrate*140} '
                                   f'-maxrate {bitrate*140} -bufsize 2M -preset slow -c:a aac -af "volume=-7dB" '
                                   f'-y "{item_path}/{config["output_dirs"].split(",")[0]}/video1.mp4"',
                                         shell=True)


### PR DESCRIPTION
The ffmpeg command for mp4 trailer processing is missing a space at the end of the line, resulting in a faulty command like this: `ffmpeg -i "cache/columbus.mp4"  -threads 2 -vf crop=1920:1024:0:28 -c:v libx264 -b:v 3920-maxrate 3920 -bufsize 2M -preset slow -c:a aac -af "volume=-7dB" -y "/media/movies/en/Columbus (2017)/trailers/video1.mp4"` (`-b:v 3920-maxrate 3920` should be `-b:v 3920 -maxrate 3920`)

Adding a space at the end of line 306 fixes the command.